### PR TITLE
Add nix package definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ osx_volname
 dist/
 
 /guix-build-*
+
+# nix
+result

--- a/default.nix
+++ b/default.nix
@@ -69,15 +69,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    description = "Open Source implementation of advanced blockchain features extending the Bitcoin protocol";
-    longDescription= ''
-      The Elements blockchain platform is a collection of feature experiments and extensions to the
-      Bitcoin protocol. This platform enables anyone to build their own businesses or networks
-      pegged to Bitcoin as a sidechain or run as a standalone blockchain with arbitrary asset
-      tokens.
-    '';
-    homepage = "https://www.github.com/ElementsProject/elements";
-    maintainers = with maintainers; [ prusnak ];
+    description = "Sequentia is a Bitcoin sidechain dedicated to asset tokenization and decentralized exchanges";
+    homepage = "https://www.github.com/SequentiaSEQ/SEQ-Core-Elements";
+    maintainers = [];
     license = licenses.mit;
     platforms = platforms.unix;
   };

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, util-linux
+, hexdump
+, autoSignDarwinBinariesHook ? null
+, wrapQtAppsHook ? null
+, boost
+, libevent
+, miniupnpc
+, zeromq
+, zlib
+, db48
+, sqlite
+, qrencode
+, qtbase ? null
+, qttools ? null
+, python3
+, withGui ? false
+, withWallet ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = if withGui then "sequentia" else "sequentiad";
+  version = "23.2.1";
+
+  src = ./.;
+
+  nativeBuildInputs =
+    [ autoreconfHook pkg-config ]
+    ++ lib.optionals stdenv.isLinux [ util-linux ]
+    ++ lib.optionals stdenv.isDarwin [ hexdump ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ lib.optionals withGui [ wrapQtAppsHook ];
+
+  buildInputs = [ boost libevent miniupnpc zeromq zlib ]
+    ++ lib.optionals withWallet [ db48 sqlite ]
+    ++ lib.optionals withGui [ qrencode qtbase qttools ];
+
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--disable-bench"
+  ] ++ lib.optionals (!doCheck) [
+    "--disable-tests"
+    "--disable-gui-tests"
+  ] ++ lib.optionals (!withWallet) [
+    "--disable-wallet"
+  ] ++ lib.optionals withGui [
+    "--with-gui=qt5"
+    "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  # fix "Killed: 9  test/test_bitcoin"
+  # https://github.com/NixOS/nixpkgs/issues/179474
+  hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "fortify" "stackprotector" ];
+
+  nativeCheckInputs = [ python3 ];
+
+  doCheck = false;
+
+  checkFlags =
+    [ "LC_ALL=en_US.UTF-8" ]
+    # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
+    # See also https://github.com/NixOS/nixpkgs/issues/24256
+    ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Open Source implementation of advanced blockchain features extending the Bitcoin protocol";
+    longDescription= ''
+      The Elements blockchain platform is a collection of feature experiments and extensions to the
+      Bitcoin protocol. This platform enables anyone to build their own businesses or networks
+      pegged to Bitcoin as a sidechain or run as a standalone blockchain with arbitrary asset
+      tokens.
+    '';
+    homepage = "https://www.github.com/ElementsProject/elements";
+    maintainers = with maintainers; [ prusnak ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,0 +1,10 @@
+let
+  systemPkgs = import <nixpkgs> {};
+  nixpkgs-repo = systemPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "0deaf4d5d224fac3cb2ae9c92a4e349c277be982";
+    sha256 = "sha256-uERpVxRrCUB7ySkGb3NtDmzEkPDn23VfkCtT2hJZty8=";
+  };
+  pkgs = import nixpkgs-repo {};
+in pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+let 
+	pkgs = import ./pkgs.nix;
+	sequentia = pkgs.callPackage ./default.nix {};
+in pkgs.mkShell {
+	inputsFrom = [
+		sequentia
+	];
+} 

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
 let 
-	pkgs = import ./pkgs.nix;
-	sequentia = pkgs.callPackage ./default.nix {};
+  pkgs = import ./pkgs.nix;
+  sequentia = pkgs.callPackage ./default.nix {};
 in pkgs.mkShell {
-	inputsFrom = [
-		sequentia
-	];
+  inputsFrom = [
+    sequentia
+  ];
 } 


### PR DESCRIPTION
Adds package definition and minimal development shell for building with [nix](https://nixos.org/).

The package definition is based on the existing package definition for `elements` found here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/blockchains/elements/default.nix

At some point, we can try to upstream the package definition so that users can install a sequentia node with a single command line. Presumably people are already doing this with elements and so this will help with onboarding them.