### PR TITLE
Test fees in every asset

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1512,6 +1512,11 @@ public:
         UpdateElementsActivationParametersFromArgs(consensus, args);
 
         // END ELEMENTS fields
+
+        // SEQUENTIA fields
+        g_con_sequentiamode = true;
+
+        // END SEQUENTIA fields
     }
 
     // XXX: This is copy-and-pasted from CCustomParams; sharing it would be better, but is annoying.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1512,11 +1512,6 @@ public:
         UpdateElementsActivationParametersFromArgs(consensus, args);
 
         // END ELEMENTS fields
-
-        // SEQUENTIA fields
-        g_con_sequentiamode = true;
-
-        // END SEQUENTIA fields
     }
 
     // XXX: This is copy-and-pasted from CCustomParams; sharing it would be better, but is annoying.

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -257,6 +257,11 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         if (!MoneyRange(fee_map)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-total-fee-outofrange");
         }
+        if (g_con_sequentiamode) {
+            if (fee_map.size() > 1) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-block-fees", "fees can only be paid on one currency");
+            }
+        }
     } else {
         const CAmount value_out = tx.GetValueOutMap()[CAsset()];
         if (nValueIn < value_out) {

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -151,6 +151,9 @@ private:
     const CTxMemPool& m_mempool;
     CChainState& m_chainstate;
 
+    // SEQUENTIA:
+    CAmountMap feeMap;
+
 public:
     struct Options {
         Options();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -13,7 +13,7 @@
 #include <assert.h>
 
 bool g_con_elementsmode = false;
-bool g_con_sequentiamode = false;
+bool g_con_sequentiamode = true;
 
 const int32_t CTransaction::CURRENT_VERSION = 2;
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 bool g_con_elementsmode = false;
+bool g_con_sequentiamode = false;
 
 const int32_t CTransaction::CURRENT_VERSION = 2;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -28,6 +28,9 @@ static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 // Globals to avoid circular dependencies.
 extern bool g_con_elementsmode;
 
+// SEQUENTIA:
+extern bool g_con_sequentiamode;
+
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -137,6 +137,7 @@ static std::vector<RPCArg> CreateTxDoc()
                 {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
                     {
                         {"fee", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The key is \"fee\", the value the fee output you want to add."},
+                        {"asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The asset tag for the fee if it is not the main chain asset"},
                     },
                     },
             },

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -322,9 +322,12 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 // ELEMENTS: explicit fee outputs
                 CAmount nAmount = AmountFromValue(output[name_]);
                 out.nValue = nAmount;
+                
                 // SEQUENTIA: Allow fees in any asset
-                if (output.exists("asset")) {
-                    out.nAsset = CAsset(ParseHashO(output, "asset"));
+                if (g_con_sequentiamode) {
+                    if (output.exists("asset")) {
+                        out.nAsset = CAsset(ParseHashO(output, "asset"));
+                    }
                 }
                 out.scriptPubKey = CScript();
                 is_fee = true;

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -322,6 +322,10 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 // ELEMENTS: explicit fee outputs
                 CAmount nAmount = AmountFromValue(output[name_]);
                 out.nValue = nAmount;
+                // SEQUENTIA: Allow fees in any asset
+                if (output.exists("asset")) {
+                    out.nAsset = CAsset(ParseHashO(output, "asset"));
+                }
                 out.scriptPubKey = CScript();
                 is_fee = true;
                 break;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -104,6 +104,27 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
       nSigOpCostWithAncestors{sigOpCost},
       setPeginsSpent(_setPeginsSpent) {}
 
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+                                 int64_t time, unsigned int entry_height,
+                                 bool spends_coinbase, int64_t sigops_cost, LockPoints lp,
+                                 const std::set<std::pair<uint256, COutPoint>>& _setPeginsSpent)
+    : tx{tx},
+      nFee{fee},
+      feeAsset{feeAsset},
+      nTxWeight(GetTransactionWeight(*tx)),
+      nUsageSize{RecursiveDynamicUsage(tx)},
+      nTime{time},
+      entryHeight{entry_height},
+      spendsCoinbase{spends_coinbase},
+      sigOpCost{sigops_cost},
+      lockPoints{lp},
+      nSizeWithDescendants{GetTxSize()},
+      nModFeesWithDescendants{nFee},
+      nSizeWithAncestors{GetTxSize()},
+      nModFeesWithAncestors{nFee},
+      nSigOpCostWithAncestors{sigOpCost},
+      setPeginsSpent(_setPeginsSpent) {}
+
 void CTxMemPoolEntry::UpdateFeeDelta(int64_t newFeeDelta)
 {
     nModFeesWithDescendants += newFeeDelta - feeDelta;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -118,6 +118,9 @@ private:
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 
+    // SEQUENTIA:
+    const CAsset feeAsset;
+
 public:
     CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
                     int64_t time, unsigned int entry_height,
@@ -169,6 +172,15 @@ public:
 
     // ELEMENTS:
     std::set<std::pair<uint256, COutPoint>> setPeginsSpent;
+
+    // SEQUENTIA:
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset,
+            int64_t time, unsigned int entry_height,
+            bool spends_coinbase,
+            int64_t sigops_cost, LockPoints lp,
+            const std::set<std::pair<uint256, COutPoint>>& setPeginsSpent);
+
+    const CAsset& GetFeeAsset() const { return feeAsset; }
 };
 
 // extracts a transaction hash from CTxMemPoolEntry or CTransactionRef


### PR DESCRIPTION
Passes an integration test that includes asset issuance, fee payment in non-native asset, and non-native asset rewards to miner. See: https://github.com/MuKnSys/gerbil-sequentia/blob/master/scripts/test-scenarios.ss#L160-L193

It's undoubtedly missing some edge cases but it should be good enough for initial testing and experimentation.

Current limitations:
- Requires using the `createrawtransaction` JSON RPC for non-native fee payments
- Fees can only be paid with a single asset

Untested:
- Mining blocks containing multiple assets
- Using block signing mechanism rather than mining