### PR TITLE
Add python3 and clang-tools to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,4 +5,8 @@ in pkgs.mkShell {
   inputsFrom = [
     sequentia
   ];
+  buildInputs = [
+    pkgs.python3
+    pkgs.clang-tools
+  ];
 }


### PR DESCRIPTION
`python3` for testing, and `clang-tools` for linting / code formatting.