### PR TITLE
Use nFees for amounts and nFeeValue for value

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -305,7 +305,7 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     nBlockWeight += iter->GetTxWeight();
     ++nBlockTx;
     nBlockSigOpsCost += iter->GetSigOpCost();
-    feeMap[iter->GetFeeAsset()] += iter->GetFeeAmount();
+    feeMap[iter->GetFeeAsset()] += iter->GetFee();
     inBlock.insert(iter);
 
     bool fPrintPriority = gArgs.GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -68,14 +68,14 @@ private:
     int64_t feeDelta;
 };
 
-struct update_fee
+struct update_fee_value
 {
-    explicit update_fee(int64_t _fee) : fee(_fee) { }
+    explicit update_fee_value(int64_t _feeValue) : feeValue(_feeValue) { }
 
-    void operator() (CTxMemPoolEntry &e) { e.UpdateFee(fee); }
+    void operator() (CTxMemPoolEntry &e) { e.UpdateFeeValue(feeValue); }
 
 private:
-    int64_t fee;
+    int64_t feeValue;
 };
 
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
@@ -95,14 +95,14 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
     return true;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeAmount,
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset feeAsset, CAmount feeValue,
                                  int64_t time, unsigned int entry_height,
                                  bool spends_coinbase, int64_t sigops_cost, LockPoints lp,
                                  const std::set<std::pair<uint256, COutPoint>>& _setPeginsSpent)
     : tx{tx},
       nFee{fee},
       nFeeAsset{feeAsset},
-      nFeeAmount{feeAmount},
+      nFeeValue{feeValue},
       nTxWeight(GetTransactionWeight(*tx)),
       nUsageSize{RecursiveDynamicUsage(tx)},
       nTime{time},
@@ -111,9 +111,9 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, CAsset 
       sigOpCost{sigops_cost},
       lockPoints{lp},
       nSizeWithDescendants{GetTxSize()},
-      nModFeesWithDescendants{nFee},
+      nModFeesWithDescendants{nFeeValue},
       nSizeWithAncestors{GetTxSize()},
-      nModFeesWithAncestors{nFee},
+      nModFeesWithAncestors{nFeeValue},
       nSigOpCostWithAncestors{sigOpCost},
       setPeginsSpent(_setPeginsSpent) {}
 
@@ -124,11 +124,11 @@ void CTxMemPoolEntry::UpdateFeeDelta(int64_t newFeeDelta)
     feeDelta = newFeeDelta;
 }
 
-void CTxMemPoolEntry::UpdateFee(const CAmount newFee)
+void CTxMemPoolEntry::UpdateFeeValue(const CAmount newFeeValue)
 {
-    nModFeesWithDescendants += newFee - nFee;
-    nModFeesWithAncestors += newFee - nFee;
-    nFee = newFee;
+    nModFeesWithDescendants += newFeeValue - nFeeValue;
+    nModFeesWithAncestors += newFeeValue - nFeeValue;
+    nFeeValue = newFeeValue;
 }
 
 void CTxMemPoolEntry::UpdateLockPoints(const LockPoints& lp)
@@ -1073,10 +1073,10 @@ void CTxMemPool::RecomputeFees()
         ExchangeRateMap exchangeRateMap = ExchangeRateMap::GetInstance();
         for (CTxMemPoolEntry tx : mapTx) {
             txiter it = mapTx.find(tx.GetTx().GetHash());
-            CAmount newFee = exchangeRateMap.CalculateExchangeValue(tx.GetFeeAmount(), tx.GetFeeAsset());
-            CAmount feeDelta = newFee - tx.GetFee();
-            if (feeDelta != 0) {
-                mapTx.modify(it, update_fee(newFee));
+            CAmount newFeeValue = exchangeRateMap.CalculateExchangeValue(tx.GetFee(), tx.GetFeeAsset());
+            CAmount feeValueDelta = newFeeValue - tx.GetFeeValue();
+            if (feeValueDelta != 0) {
+                mapTx.modify(it, update_fee_value(newFeeValue));
                 
                 // Now update all ancestors' modified fees with descendants
                 setEntries setAncestors;
@@ -1084,14 +1084,14 @@ void CTxMemPool::RecomputeFees()
                 std::string dummy;
                 CalculateMemPoolAncestors(tx, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
                 for (txiter ancestorIt : setAncestors) {
-                    mapTx.modify(ancestorIt, update_descendant_state(0, feeDelta, 0));
+                    mapTx.modify(ancestorIt, update_descendant_state(0, feeValueDelta, 0));
                 }
                 // Now update all descendants' modified fees with ancestors
                 setEntries setDescendants;
                 CalculateDescendants(it, setDescendants);
                 setDescendants.erase(it);
                 for (txiter descendantIt : setDescendants) {
-                    mapTx.modify(descendantIt, update_ancestor_state(0, feeDelta, 0, 0));
+                    mapTx.modify(descendantIt, update_ancestor_state(0, feeValueDelta, 0, 0));
                 }
                 ++nTransactionsUpdated;
             }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -95,9 +95,9 @@ private:
     const CTransactionRef tx;
     mutable Parents m_parents;
     mutable Children m_children;
-    CAmount nFee;                   //!< Value in reference unit, computed using configured exchange rates. It is not a `const` because it needs to be updated whenever exchange rates change.
+    const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
     const CAsset nFeeAsset;         //!< ELEMENTS: The asset used for fee payment. Always equal to policyAsset unless con_any_asset_fees is enabled.
-    const CAmount nFeeAmount;       //!< ELEMENTS: The amount of nFeeAsset used for fee payment. Always equal to nFee unless con_any_asset_fees is enabled.
+    CAmount nFeeValue;              //!< ELEMENTS: Value in reference unit, computed using configured exchange rates. It is not a `const` because it needs to be updated whenever exchange rates change.
     const size_t nTxWeight;         //!< ... and avoid recomputing tx weight (also used for GetTxSize())
     const size_t nUsageSize;        //!< ... and total memory usage
     const int64_t nTime;            //!< Local time when entering the mempool
@@ -121,7 +121,7 @@ private:
     int64_t nSigOpCostWithAncestors;
 
 public:
-    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, const CAsset feeAsset, const CAmount feeAmount,
+    CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee, const CAsset feeAsset, const CAmount feeValue,
                 int64_t time, unsigned int entry_height,
                 bool spends_coinbase,
                 int64_t sigops_cost, LockPoints lp,
@@ -131,7 +131,7 @@ public:
     CTransactionRef GetSharedTx() const { return this->tx; }
     const CAmount& GetFee() const { return nFee; }
     const CAsset& GetFeeAsset() const { return nFeeAsset; }
-    const CAmount& GetFeeAmount() const { return nFeeAmount; }
+    const CAmount& GetFeeValue() const { return nFeeValue; }
     size_t GetTxSize() const;
     size_t GetTxWeight() const { return nTxWeight; }
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
@@ -148,8 +148,8 @@ public:
     // Updates the fee delta used for mining priority score, and the
     // modified fees with descendants.
     void UpdateFeeDelta(int64_t feeDelta);
-    // Updates the base fee and the modified fees with ancestors and descendants.
-    void UpdateFee(const CAmount fee);
+    // Updates the fee value and the modified fees with ancestors and descendants.
+    void UpdateFeeValue(const CAmount fee);
     // Update the LockPoints after a reorg
     void UpdateLockPoints(const LockPoints& lp);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -915,8 +915,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         }
     }
 
-    CAmount currentFeeValuation = ExchangeRateMap::GetInstance().CalculateExchangeValue(ws.m_base_fees, feeAsset);
-    entry.reset(new CTxMemPoolEntry(ptx, currentFeeValuation, feeAsset, ws.m_base_fees, nAcceptTime, m_active_chainstate.m_chain.Height(),
+    CAmount currentFeeValue = ExchangeRateMap::GetInstance().CalculateExchangeValue(ws.m_base_fees, feeAsset);
+    entry.reset(new CTxMemPoolEntry(ptx, ws.m_base_fees, feeAsset, currentFeeValue, nAcceptTime, m_active_chainstate.m_chain.Height(),
             fSpendsCoinbase, nSigOpsCost, lp, setPeginsSpent));
     ws.m_vsize = entry->GetTxSize();
 


### PR DESCRIPTION
Instead of using CTxMemPoolEntry's `nFee` field to represent the node's valuation of the transaction, this introduces a new field named `nFeeValue` to use instead, and removes the `nFeeAmount` field that had previously assumed the role of `nFee`.

In other words:
- `nFee`: amount of fee in whatever asset it's paid in
- `nFeeValue`: the node's valuation of that fee based on current exchange rates

This makes it both more consistent with upstream and clarifies that `nFeeValue` is a new element being introduced by the any asset fee feature.
