### PR TITLE
Decimal denomination to assets

### DIFF
--- a/src/issuance.cpp
+++ b/src/issuance.cpp
@@ -85,6 +85,7 @@ void AppendInitialIssuance(CBlock& genesis_block, const COutPoint& prevout, cons
     txNew.vin[0].assetIssuance.assetEntropy = contract;
     txNew.vin[0].assetIssuance.nAmount = CConfidentialValue(asset_values * asset_outputs);
     txNew.vin[0].assetIssuance.nInflationKeys = CConfidentialValue(reissuance_values * reissuance_outputs);
+    txNew.vin[0].assetIssuance.denomination = 8;
 
     for (unsigned int i = 0; i < asset_outputs; i++) {
         txNew.vout.push_back(CTxOut(asset, CConfidentialValue(asset_values), issuance_destination));

--- a/src/primitives/confidential.cpp
+++ b/src/primitives/confidential.cpp
@@ -29,6 +29,7 @@ std::string CAssetIssuance::ToString() const
         str += strprintf(", amount=%s", (nAmount.IsExplicit() ? strprintf("%d.%08d", nAmount.GetAmount() / COIN, nAmount.GetAmount() % COIN) : std::string("CONFIDENTIAL")));
     if (!nInflationKeys.IsNull())
         str += strprintf(", inflationkeys=%s", (nInflationKeys.IsExplicit() ? strprintf("%d.%08d", nInflationKeys.GetAmount() / COIN, nInflationKeys.GetAmount() % COIN) : std::string("CONFIDENTIAL")));
+    str += std::to_string(denomination);
     str += ")";
     return str;
 }

--- a/src/primitives/confidential.cpp
+++ b/src/primitives/confidential.cpp
@@ -29,7 +29,7 @@ std::string CAssetIssuance::ToString() const
         str += strprintf(", amount=%s", (nAmount.IsExplicit() ? strprintf("%d.%08d", nAmount.GetAmount() / COIN, nAmount.GetAmount() % COIN) : std::string("CONFIDENTIAL")));
     if (!nInflationKeys.IsNull())
         str += strprintf(", inflationkeys=%s", (nInflationKeys.IsExplicit() ? strprintf("%d.%08d", nInflationKeys.GetAmount() / COIN, nInflationKeys.GetAmount() % COIN) : std::string("CONFIDENTIAL")));
-    str += std::to_string(denomination);
+    str += strprintf("%d", denomination);
     str += ")";
     return str;
 }

--- a/src/primitives/confidential.h
+++ b/src/primitives/confidential.h
@@ -192,13 +192,15 @@ public:
     // generating transaction.
     CConfidentialValue nInflationKeys;
 
+    uint8_t denomination = 8;
+
 public:
     CAssetIssuance()
     {
         SetNull();
     }
 
-    SERIALIZE_METHODS(CAssetIssuance, obj) { READWRITE(obj.assetBlindingNonce, obj.assetEntropy, obj.nAmount, obj.nInflationKeys); }
+    SERIALIZE_METHODS(CAssetIssuance, obj) { READWRITE(obj.assetBlindingNonce, obj.assetEntropy, obj.nAmount, obj.nInflationKeys, obj.denomination); }
 
     void SetNull() { nAmount.SetNull(); nInflationKeys.SetNull(); }
     bool IsNull() const { return (nAmount.IsNull() && nInflationKeys.IsNull()); }
@@ -209,6 +211,7 @@ public:
                a.assetEntropy == b.assetEntropy &&
                a.nAmount == b.nAmount &&
                a.nInflationKeys == b.nInflationKeys;
+               a.denomination == b.denomination;
     }
 
     friend bool operator!=(const CAssetIssuance& a, const CAssetIssuance& b)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -225,6 +225,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "issueasset", 0, "assetamount" },
     { "issueasset", 1, "tokenamount" },
     { "issueasset", 2, "blind" },
+    { "issueasset", 5, "denomination" },
     { "reissueasset", 1, "assetamount" },
     { "initpegoutwallet", 1, "bip32_counter"},
     { "rawblindrawtransaction", 1, "inputamountblinders" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -3008,7 +3008,7 @@ static RPCHelpMan rawissueasset()
                                     {"asset_address", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Destination address of generated asset. Required if `asset_amount` given."},
                                     {"token_amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED_NAMED_ARG, "Amount of reissuance token to generate, if any."},
                                     {"token_address", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Destination address of generated reissuance tokens. Required if `token_amount` given."},
-                                    {"blind", RPCArg::Type::BOOL, RPCArg::Default{true}, "Whether to mark the issuance input for blinding or not. Only affects issuances with re-issuance tokens."},
+                                    {"blind", RPCArg::Type::BOOL, RPCArg::Default{false}, "Whether to mark the issuance input for blinding or not. Only affects issuances with re-issuance tokens."},
                                     {"contract_hash", RPCArg::Type::STR_HEX, RPCArg::Default{"0000...0000"}, "Contract hash that is put into issuance definition. Must be 32 bytes worth in hex string form. This will affect the asset id."},
                                     {"denomination", RPCArg::Type::NUM, RPCArg::Default{8}, "Number of decimals to denominate the asset - default: 8\n"},
                                 }
@@ -3103,8 +3103,10 @@ static RPCHelpMan rawissueasset()
         }
 
         // If we have issuances, check if reissuance tokens will be generated via blinding path
-        const UniValue blind_uni = issuance_o["blind"];
-        const bool blind_issuance = !blind_uni.isBool() || blind_uni.get_bool();
+        bool blind_issuance = false;
+        if (!issuance_o["blind"].isNull()) {
+            blind_issuance = issuance_o["blind"].get_bool();
+        }
 
         // Check for optional contract to hash into definition
         uint256 contract_hash;
@@ -3112,7 +3114,7 @@ static RPCHelpMan rawissueasset()
             contract_hash = ParseHashV(issuance_o["contract_hash"], "contract_hash");
         }
 
-        uint8_t denomination = 0;
+        uint8_t denomination = 8;
         if (!issuance_o["denomination"].isNull()) {
             denomination = issuance_o["denomination"].get_int();
         }

--- a/src/wallet/rpc/elements.cpp
+++ b/src/wallet/rpc/elements.cpp
@@ -1396,7 +1396,7 @@ RPCHelpMan issueasset()
                 {
                     {"assetamount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Amount of asset to generate. Note that the amount is BTC-like, with 8 decimal places."},
                     {"tokenamount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Amount of reissuance tokens to generate. Note that the amount is BTC-like, with 8 decimal places. These will allow you to reissue the asset if in wallet using `reissueasset`. These tokens are not consumed during reissuance."},
-                    {"blind", RPCArg::Type::BOOL, RPCArg::Default{true}, "Whether to blind the issuances."},
+                    {"blind", RPCArg::Type::BOOL, RPCArg::Default{false}, "Whether to blind the issuances."},
                     {"contract_hash", RPCArg::Type::STR_HEX, RPCArg::Default{"0000...0000"}, "Contract hash that is put into issuance definition. Must be 32 bytes worth in hex string form. This will affect the asset id."},
                     {"fee_asset", RPCArg::Type::STR, RPCArg::DefaultHint{"not set, fall back to fee asset in existing transaction"}, "Asset to use to pay the fees"},
                     {"denomination", RPCArg::Type::NUM, RPCArg::Default{8}, "Number of decimals to denominate the asset - default: 8\n"},
@@ -1433,11 +1433,14 @@ RPCHelpMan issueasset()
         throw JSONRPCError(RPC_TYPE_ERROR, "Issuance must have one non-zero component");
     }
 
-    bool blind_issuances = request.params.size() < 3 || request.params[2].get_bool();
+    bool blind_issuances = false;
+    if (!request.params[2].isNull()) {
+        blind_issuances = request.params[2].get_bool();
+    }
 
     // Check for optional contract to hash into definition
     uint256 contract_hash;
-    if (request.params.size() >= 4) {
+    if (!request.params[3].isNull()) {
         contract_hash = ParseHashV(request.params[3], "contract_hash");
     }
 
@@ -1471,7 +1474,7 @@ RPCHelpMan issueasset()
     issuance_details.contract_hash = contract_hash;
     CCoinControl coin_control;
     if (g_con_any_asset_fees) {
-        if (request.params.size() >= 5) {
+        if (!request.params[4].isNull()) {
             CAsset fee_asset = ::policyAsset;
             std::string feeAssetString = request.params[4].get_str();
             fee_asset = GetAssetFromString(feeAssetString);
@@ -1480,7 +1483,7 @@ RPCHelpMan issueasset()
             }
             coin_control.m_fee_asset = fee_asset;
         }
-        if (request.params.size() >= 6) {
+        if (!request.params[5].isNull()) {
             issuance_details.denomination = request.params[5].get_int();
         }
     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1410,6 +1410,8 @@ static bool CreateTransactionInternal(
                     }
                 }
             }
+            // SEQUENTIA: Add denomination in the asset issuance
+            txNew.vin[0].assetIssuance.denomination = issuance_details->denomination;
         // Asset being reissued with explicitly named asset/token
         } else if (asset_index != -1) {
             assert(reissuance_index != -1);
@@ -1693,7 +1695,7 @@ static bool CreateTransactionInternal(
     }
 
     if (g_con_any_asset_fees) {
-        CAmount nFeeRetValue = ExchangeRateMap::GetInstance().ConvertAmountToValue(nFeeRet, coin_selection_params.m_fee_asset).GetValue(); 
+        CAmount nFeeRetValue = ExchangeRateMap::GetInstance().ConvertAmountToValue(nFeeRet, coin_selection_params.m_fee_asset).GetValue();
         if (nFeeRetValue > wallet.m_default_max_tx_fee) {
             error = TransactionErrorString(TransactionError::MAX_FEE_EXCEEDED);
             return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -154,6 +154,9 @@ struct IssuanceDetails {
     CAsset reissuance_asset;
     CAsset reissuance_token;
     uint256 entropy;
+
+    // SEQUENTIA: Asset denomination
+    uint8_t denomination = 8;
 };
 //end ELEMENTS
 

--- a/test/functional/example_elements_code_tutorial.py
+++ b/test/functional/example_elements_code_tutorial.py
@@ -64,8 +64,8 @@ class WalletTest(BitcoinTestFramework):
 
         expected_amt = {
             'bitcoin': 0,
-            '8f1560e209f6bcac318569a935a0b2513c54f326ee4820ccd5b8c1b1b4632373': 0,
-            '4fa41f2929d4bf6975a55967d9da5b650b6b9bfddeae4d7b54b04394be328f7f': 99
+            '884071e106da92ff53b432340c8d160066502c781f50dfac5afc67459f946d6f': 0,
+            'daa8284c0d06cb02ef28b75ffa74c3b512131884d9c72e4f11dac634703d4fc4': 99
         }
         assert self.nodes[0].gettransaction(reissuance_txid)['amount'] == expected_amt
 

--- a/test/functional/feature_any_asset_fee_rates.py
+++ b/test/functional/feature_any_asset_fee_rates.py
@@ -43,7 +43,7 @@ class AnyAssetFeeRatesTest(BitcoinTestFramework):
         self.gasset = 'b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23'
 
         self.issue_amount = Decimal('100')
-        self.issuance = self.nodes[0].issueasset(self.issue_amount, 1)
+        self.issuance = self.nodes[0].issueasset(self.issue_amount, 1, False)
         self.asset = self.issuance['asset']
         self.issuance_txid = self.issuance['txid']
         self.issuance_vin = self.issuance['vin']

--- a/test/functional/feature_any_asset_fee_rbf.py
+++ b/test/functional/feature_any_asset_fee_rbf.py
@@ -38,7 +38,7 @@ class AnyAssetFeeTest(BitcoinTestFramework):
 
         self.gasset = self.nodes[0].dumpassetlabels()['gasset']
         self.issue_amount = Decimal('100')
-        self.issuance = self.nodes[0].issueasset(self.issue_amount, 1)
+        self.issuance = self.nodes[0].issueasset(self.issue_amount, 1, False)
         self.asset = self.issuance['asset']
         #token = issuance['token']
         self.issuance_txid = self.issuance['txid']

--- a/test/functional/feature_any_asset_fee_scenarios.py
+++ b/test/functional/feature_any_asset_fee_scenarios.py
@@ -41,7 +41,7 @@ class AnyAssetFeeScenariosTest(BitcoinTestFramework):
         self.node1_address = self.nodes[1].getnewaddress()
 
         self.issue_amount1 = Decimal('100')
-        self.issuance1 = self.nodes[0].issueasset(self.issue_amount1, 1)
+        self.issuance1 = self.nodes[0].issueasset(self.issue_amount1, 1, False)
         self.asset1 = self.issuance1['asset']
         self.issuance_txid1 = self.issuance1['txid']
         self.issuance_vin1 = self.issuance1['vin']
@@ -74,7 +74,6 @@ class AnyAssetFeeScenariosTest(BitcoinTestFramework):
                 assetamount=self.issue_amount2,
                 tokenamount=1,
                 blind=False,
-                contract_hash=self.asset1,
                 fee_asset = self.asset1)
         self.asset2 = self.issuance2['asset']
         self.issuance_txid2 = self.issuance2['txid']

--- a/test/functional/feature_txwitness.py
+++ b/test/functional/feature_txwitness.py
@@ -203,9 +203,10 @@ class TxWitnessTest(BitcoinTestFramework):
         block_witness_stuffed.vtx[0].vin[0].scriptSig = coinbase_orig.scriptSig
         block_witness_stuffed.vtx[0].vin[0].nSequence = coinbase_orig.nSequence
         block_witness_stuffed.vtx[0].vin[0].assetIssuance.nAmount.setToAmount(1)
+        block_witness_stuffed.vtx[0].vin[0].assetIssuance.denomination = 8
         bad_coinbase_ser_size = len(block_witness_stuffed.vtx[0].vin[0].serialize())
-        # 32+32+9+1 should be serialized for each assetIssuance field
-        assert_equal(bad_coinbase_ser_size, coinbase_ser_size+32+32+9+1)
+        # 32+32+9+1+1 should be serialized for each assetIssuance field
+        assert_equal(bad_coinbase_ser_size, coinbase_ser_size+32+32+9+1+1)
         assert not block_witness_stuffed.vtx[0].vin[0].assetIssuance.isNull()
         assert_raises_rpc_error(-22, "TX decode failed", self.nodes[0].decoderawtransaction, block_witness_stuffed.vtx[0].serialize().hex())
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -391,13 +391,14 @@ OUTPOINT_PEGIN_FLAG = (1 << 30)
 OUTPOINT_INDEX_MASK = 0x3fffffff
 
 class CAssetIssuance():
-    __slots__ = ("assetBlindingNonce", "assetEntropy", "nAmount", "nInflationKeys")
+    __slots__ = ("assetBlindingNonce", "assetEntropy", "nAmount", "nInflationKeys", "denomination")
 
     def __init__(self):
         self.assetBlindingNonce = 0
         self.assetEntropy = 0
         self.nAmount = CTxOutValue()
         self.nInflationKeys = CTxOutValue()
+        self.denomination = 8
 
     def isNull(self):
         return self.nAmount.isNull() and self.nInflationKeys.isNull()
@@ -409,6 +410,7 @@ class CAssetIssuance():
         self.nAmount.deserialize(f)
         self.nInflationKeys = CTxOutValue()
         self.nInflationKeys.deserialize(f)
+        self.denomination = deser_compact_size(f)
 
     def serialize(self):
         r = b""
@@ -416,6 +418,7 @@ class CAssetIssuance():
         r += ser_uint256(self.assetEntropy)
         r += self.nAmount.serialize()
         r += self.nInflationKeys.serialize()
+        r += ser_compact_size(self.denomination)
         return r
 
     # serialization of asset issuance used in taproot sighash


### PR DESCRIPTION
Add decimal denomination metadata to each issued asset. This data should be parsed by wallets and UI. For now all RPCs stay the same and do not take denomination when displaying amounts - all amounts displayed in 8 decimal denomination by default.

NOTE: changing default asset issuance blinding to false - unblinded! 